### PR TITLE
Fix typos in Bayes theorem post

### DIFF
--- a/_posts/2018-11-14-bayes-theorem-without-p(b).md
+++ b/_posts/2018-11-14-bayes-theorem-without-p(b).md
@@ -22,11 +22,11 @@ $$ P(A∣B) $$ is the probability of event A occurring given that B is true.
 
 $$ P(B∣A) $$ is the probability of event B occurring given that A is true.
 
-$$ P(A) $$ is the probability of A occurring. This is know as the "prior".
+$$ P(A) $$ is the probability of A occurring. This is known as the "prior".
 
 $$ P(B) $$ is the probability of B occurring.
 
-A and B are variables that can represent anything, but, in general, A is the the hypothesis you want to test and B is the new evidence. You want to know what is the probability of hypothesis A given that you just saw evidence B. When it's used in that context, you'll often see it written like this:
+A and B are variables that can represent anything, but, in general, A is the hypothesis you want to test and B is the new evidence. You want to know what is the probability of hypothesis A given that you just saw evidence B. When it's used in that context, you'll often see it written like this:
 
 $$ P(H|E) = \frac{P(E|H) \times P(H)}{P(E)} $$
 


### PR DESCRIPTION
## Summary
- fix repeated word and mis-typed phrase in Bayes theorem post

## Testing
- `bundle exec jekyll build` *(fails: `bundler: command not found: jekyll`)*