### PR TITLE
Add dataset download note in Enron tutorial

### DIFF
--- a/_posts/2015-06-01-data-cleaning-tutorial-with-the-enron-dataset.md
+++ b/_posts/2015-06-01-data-cleaning-tutorial-with-the-enron-dataset.md
@@ -36,6 +36,8 @@ file = "final_project_dataset.pkl"
 with open(join(path, file), "rb") as f:
     enron_data = pickle.load(f)
 ```
+The dataset isn't bundled with this post. You can download `final_project_dataset.pkl` from the Udacity [Intro to Machine Learning repository](https://github.com/udacity/intro-to-machine-learning/tree/master/final_project). Ensure `path` points to this file before running the code.
+
 
 # Exploring the Data
 


### PR DESCRIPTION
## Summary
- clarify where to download the `final_project_dataset.pkl` file in the Enron tutorial

## Testing
- `bundle exec jekyll build` *(fails: command not found)*
- `bundle install` *(fails: could not fetch specs)*