### PR TITLE
Fix missing 'decade' variable in blog post

### DIFF
--- a/_posts/2016-08-12-declining-executions-in-england-visualized.md
+++ b/_posts/2016-08-12-declining-executions-in-england-visualized.md
@@ -144,6 +144,7 @@ I graphed change in the percentage against time but also included the total numb
 x = np.array(range(6))
 y = df['Percentage']
 widths = df['Executions'].values / 100
+decade = df.index
 ```
 
 


### PR DESCRIPTION
## Summary
- define `decade` before using it in plotting code

## Testing
- `bundle exec jekyll build` *(fails: bundler couldn't find jekyll)*