### PR TITLE
Fix typos in Git cheat sheet

### DIFF
--- a/_posts/2017-01-01-git-cheat-sheet.md
+++ b/_posts/2017-01-01-git-cheat-sheet.md
@@ -20,13 +20,13 @@ A lot of people get frustrated with git (myself included) but I hope to lessen t
 
 
 There are three primary things that people should know about git:
-1. For the most part, **git is a local tool**. That means most of what happens in git happen only on your computer.
+1. For the most part, **git is a local tool**. That means most of what happens in git happens only on your computer.
 
 Many of the most common commands are completely local, such as: `status`, `commit`, `checkout`, `merge`, `rebase`, `diff`, and `log`. The *only* three that are remote are `push`, `pull`, and `fetch`.
 
-Yes, that's right. When you `git status` or `git commit -m 'bug fix'`, nothing actually happens over the Internet. It's all local to your machine. The entire git history of your project is stored locally. You actually have a clone of the remote repositories on your local machine, so you don't need an Internet connection for most of the uses. If a Github repo is your remote, you have a clone of it locally. That means that to talk to `origin/master` you don't actually need an Internet connection - you're talking to your local clone of the remote respositiory. The downside here is that if `git status` say you are up to date, it means you are up to date with your local clone of the remote master, but not necessarily the actual master.
+Yes, that's right. When you `git status` or `git commit -m 'bug fix'`, nothing actually happens over the Internet. It's all local to your machine. The entire git history of your project is stored locally. You actually have a clone of the remote repositories on your local machine, so you don't need an Internet connection for most of the uses. If a Github repo is your remote, you have a clone of it locally. That means that to talk to `origin/master` you don't actually need an Internet connection - you're talking to your local clone of the remote repository. The downside here is that if `git status` say you are up to date, it means you are up to date with your local clone of the remote master, but not necessarily the actual master.
 
-The good news is you can do so much of your workflow even without an Internet connection. You still still make git commits, change branches, make some more commits, merge a branch, and the check the git status at the end. The only thing you can't do is push those changes to GitHub.
+The good news is you can do so much of your workflow even without an Internet connection. You still make git commits, change branches, make some more commits, merge a branch, and then check the git status at the end. The only thing you can't do is push those changes to GitHub.
 
 `2`. There *is* excellent documentation, although most people skip it
 I recommend trying to understand how git is working bit by bit, because the better you understand it the less frustrated you will be (in general). But even if you don't have time to read the whole [official Git book](https://git-scm.com/book/en/v2) (which I admit I haven't read completely either), here are some helpful commands to get basic usage out of git. (Maybe read chapter 2)
@@ -71,7 +71,7 @@ The commit process consists of a few easy steps. First, you have to "stage the c
 
 3. `git add -u` - stage changed and deleted files only, without new
 
-### Commiting files
+### Committing files
 
 Now that the files are staged, you can create a commit. When you make a commit, you are expected to include a message about what your commit does. Here is how you do that:
 
@@ -79,7 +79,7 @@ Now that the files are staged, you can create a commit. When you make a commit, 
 
 ### Pushing to origin
 
-You've made your commit, so the next step is completely optional. As I said, `git` can work entirely locally, and you've make a local commit. But many people (myself included) use GitHub to maintain their `git` repositories. To push to your remote respository, you can do this:
+You've made your commit, so the next step is completely optional. As I said, `git` can work entirely locally, and you've make a local commit. But many people (myself included) use GitHub to maintain their `git` repositories. To push to your remote repository, you can do this:
 
 `git push origin master`
 
@@ -91,7 +91,7 @@ Now let's say you want these changes pulled to another computer. The way to do t
 
 ### Temporarily look at older commit (but don't plan to make changes)
 
-You can just `git checkout <last seven characters or commit>`
+You can just `git checkout <last seven characters of the commit hash>`
 
 This will put you in a detached HEAD state.
 
@@ -113,11 +113,11 @@ Then
 
 Or, if you want to revert everything: `git checkout .`
 
-### I commited a file then added it to .gitignore - now it won't go away
+### I committed a file then added it to .gitignore - now it won't go away
 
-I do this one all the time. It's like to need to commit at least one file before I remember to add it to .gitignore. What you need is:
+I do this one all the time. It's like I need to commit at least one file before I remember to add it to .gitignore. What you need is:
 
-`git rm --cached my_file_that_shouldnt_be_in_git`
+`git rm --cached my_file_that_shouldn't_be_in_git`
 
 #### But I did this to a bunch of files
 
@@ -133,7 +133,7 @@ Then commit:
 
 `git commit -m 'removed .gitignore files'`
 
-### Staging and commiting all in one
+### Staging and committing all in one
 
 If you want to combine the stage and commit steps into one you can:
 
@@ -171,11 +171,11 @@ You can make changes, break stuff, then switch back to your main branch at any t
 
 To see all your git branches:
 
-What branch are you on: `git branch`
+Which branch are you on: `git branch`
 
-What branches are there: `git branch -a`
+Which branches are there: `git branch -a`
 
-When you want to merge a branch back into it's master:
+When you want to merge a branch back into its master:
 
 ```
 git checkout <master>
@@ -188,7 +188,7 @@ git push origin <master>
 
 If you want, you can delete the branch you just merged: `git branch -d <mergedbranch>`
 
-### Syncing with upsteam branch
+### Syncing with upstream branch
 
 If you've created a branch and since then the master has been updated, you may get a message like: "This branch is X commits ahead, Y commits behind [masterbranchname]:master." Here are the steps to resolve this:
 
@@ -202,11 +202,11 @@ If this already exists, you'll get a message saying: "fatal: remote upstream alr
 
  1. Then type: `git pull upstream master`
 
-If both branches have editted the same file, you may get a conflict. If you do, follow the steps in [this article](https://help.github.com/articles/resolving-a-merge-conflict-using-the-command-line/).
+If both branches have edited the same file, you may get a conflict. If you do, follow the steps in [this article](https://help.github.com/articles/resolving-a-merge-conflict-using-the-command-line/).
 
 ### What are those weird strings of characters?
 
-Those are SHA-1 hashs. They consistent of 40 characters although git often just shows the ones at the end.
+Those are SHA-1 hashes. They consist of 40 characters although git often just shows the ones at the end.
 
 ### What can I do with my .git folder?
 
@@ -297,7 +297,7 @@ You can also, however, save your local commits in a branch before doing this
 
 ### How do I delete a branch?
 
-If you want to delete a branch completely you will need to delete it both locally and remotely. The easiest way, by far, is to use the GitHub Desktop app. You just go to the branch you want to delete, then go to the Branch menu -> Delete -> Check checkbox to for "Yes, delete this branch on the remote" If that's not an option you'll need to do both independently like so:
+If you want to delete a branch completely you will need to delete it both locally and remotely. The easiest way, by far, is to use the GitHub Desktop app. You just go to the branch you want to delete, then go to the Branch menu -> Delete -> check the checkbox for "Yes, delete this branch on the remote" If that's not an option you'll need to do both independently like so:
 
 #### Delete local branch
 
@@ -326,8 +326,8 @@ If there are files or directories still hanging around (like maybe they're being
 Your files are always in one of three states with git: modified, staged, and committed
 
 * Modified means you have changed it
-* Staged means it will be commited during your next commit
-* Commited means it is stored in your (local) database, ready to be modified again
+* Staged means it will be committed during your next commit
+* Committed means it is stored in your (local) database, ready to be modified again
 
 * HEAD
 
@@ -349,16 +349,16 @@ Note that (at least on Windows) the direction of the slash matters. If you want 
 
 ## GUIs
 
-While no GUI has all the features of the command line, they are still very helpful. The one I recommend is the [GitHub Desktop](https://desktop.github.com/) app. It's easy to use and offers support for Mac and Windows. I do wish they would add Linux to that list. But it brings up the problem with GUIs - you won't always have access to them, so don't rely on them. Say you're working through an SSH tunnel on some remote server. You'll often be in the case where you **can't** use a GUI, so I still recommend learning the command line. But the GUI definitely helps to make the initial steps more gentle. I still use the GUI when possible because I think the graphical inferface makes viewing the differences much easier.
+While no GUI has all the features of the command line, they are still very helpful. The one I recommend is the [GitHub Desktop](https://desktop.github.com/) app. It's easy to use and offers support for Mac and Windows. I do wish they would add Linux to that list. But it brings up the problem with GUIs - you won't always have access to them, so don't rely on them. Say you're working through an SSH tunnel on some remote server. You'll often be in the case where you **can't** use a GUI, so I still recommend learning the command line. But the GUI definitely helps to make the initial steps more gentle. I still use the GUI when possible because I think the graphical interface makes viewing the differences much easier.
 
 
 ## Problems with git
 
-git blame - good tool  be should be renamed. Maybe `git credit`? It's a bit funny but in the end I don't think it's a good idea. I imagine it could have been done in jest but I think given the importance of git today and the difficulties of software engineering, not to mention imposter syndrome, it's not the right name.
+git blame - good tool but should be renamed. Maybe `git credit`? It's a bit funny but in the end I don't think it's a good idea. I imagine it could have been done in jest but I think given the importance of git today and the difficulties of software engineering, not to mention imposter syndrome, it's not the right name.
 
 ## Configuring git
 
-Supposed you wanted to add something that combined a few git commands, like `git pull` along with rebasing and autostashing. You could do something like this:
+Suppose you wanted to add something that combined a few git commands, like `git pull` along with rebasing and autostashing. You could do something like this:
 
 `git config --global alias.all 'pull --rebase --autostash'`
 
@@ -372,14 +372,15 @@ I also recommend this:
 
 Sometimes you might have a problem where git is not configured.
 
+```
 git config --global user.name "<Your Name>"
-
 git config --global user.email "<youremail@gmail.com>"
+```
 
 
 ## git aliases
 
-do this to git config: [aliases](https://githowto.com/aliases)
+For helpful shortcuts, see the guide on [git aliases](https://githowto.com/aliases)
 
 ## Other
 


### PR DESCRIPTION
## Summary
- fix spelling and grammar across the Git cheat sheet post
- tweak wording for clarity and wrap VSCode configuration commands in a code block
- update alias documentation link wording

## Testing
- `bundle exec jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b26c6fd5c8327bee2ae0aba47aeb9