### PR TITLE
Fix Pages build: add missing SCSS variables from upstream theme

### DIFF
--- a/_sass/base/_variables.scss
+++ b/_sass/base/_variables.scss
@@ -26,6 +26,21 @@ $break: 768px;
 $sm-break: 576px;
 $x-sm-break: 320px;
 
+/* TRANSITIONS */
+$transition-fast: 0.15s;
+$transition-base: 0.2s;
+$transition-slow: 0.5s;
+
+/* Z-INDEX */
+$z-index-cookie: 1000;
+
+/* COMPONENT SIZES */
+$post-img-height: 250px;
+$post-img-height-mobile: 150px;
+$portfolio-max-width: 400px;
+$gallery-item-width: 32.6%;
+$gallery-gutter: 1%;
+
 
 /* THEME COLOR SCHEMES */
 html, html[data-theme="light"] {


### PR DESCRIPTION
## Summary
- Pages build has been failing since late March with `Undefined variable: \$gallery-item-width` in the SCSS converter (see run [24795777108](https://github.com/jss367/jss367.github.io/actions/runs/24795777108/job/72565036492)).
- Root cause: local \`_sass/base/_variables.scss\` shadows the upstream \`sylhare/type-on-strap\` variables file. The upstream theme has added new variables that its own \`_sass/includes/*.scss\` files now reference, but our local override doesn't define them.
- This PR adds the missing variables (values copied from upstream defaults): \`\$transition-fast/base/slow\`, \`\$z-index-cookie\`, \`\$post-img-height\`, \`\$post-img-height-mobile\`, \`\$portfolio-max-width\`, \`\$gallery-item-width\`, \`\$gallery-gutter\`.

## Test plan
- [ ] GitHub Pages build succeeds on this branch
- [ ] Site renders without visible regressions (gallery, portfolio, post images, transitions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)